### PR TITLE
sync upstream main branch to downstream

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -94,6 +94,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -73,6 +73,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   build_bundle:
     name: build_bundle
-    if: github.repository == 'csi-addons/kubernetes-csi-addons'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,22 @@ BUNDLE_IMG ?= quay.io/csiaddons/k8s-bundle
 # set TAG to a release for consumption in the bundle
 TAG ?= latest
 
+# In case the *_IMG variables can contain a full qualified container-image
+# resource (includes a ":"), the container-images should not use the TAG
+# valued. The :TAG option will only be added if no predefined version is
+# passed.
+ifneq (findstring $(CONTROLLER_IMG),:)
+CONTROLLER_IMG := $(CONTROLLER_IMG):$(TAG)
+endif
+
+ifneq (findstring $(SIDECAR_IMG),:)
+SIDECAR_IMG := $(SIDECAR_IMG):$(TAG)
+endif
+
+ifneq (findstring $(BUNDLE_IMG),:)
+BUNDLE_IMG := $(BUNDLE_IMG):$(TAG)
+endif
+
 # the PACKAGE_NAME is included in the bundle/CSV and is used in catalogsources
 # for operators (like OperatorHub.io). Products that include the CSI-Addons
 # bundle should use a different PACKAGE_NAME to prevent conflicts.
@@ -72,7 +88,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: bundle
 bundle: kustomize operator-sdk
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(CONTROLLER_IMG):$(TAG) $(KUSTOMIZE_RBAC_PROXY)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(CONTROLLER_IMG) $(KUSTOMIZE_RBAC_PROXY)
 	$(KUSTOMIZE) build config/default | $(OPERATOR_SDK) generate bundle --manifests --metadata --package=$(PACKAGE_NAME) $(BUNDLE_VERSION)
 	mkdir -p ./bundle/tests/scorecard && $(KUSTOMIZE) build config/scorecard --output=./bundle/tests/scorecard/config.yaml
 
@@ -114,27 +130,27 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${CONTROLLER_IMG}:${TAG} .
+	docker build -t ${CONTROLLER_IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${CONTROLLER_IMG}:${TAG}
+	docker push ${CONTROLLER_IMG}
 
 .PHONY: docker-build-sidecar
 docker-build-sidecar:
-	docker build -f ./build/Containerfile.sidecar -t ${SIDECAR_IMG}:${TAG} .
+	docker build -f ./build/Containerfile.sidecar -t ${SIDECAR_IMG} .
 
 .PHONY: docker-push-sidecar
 docker-push-sidecar:
-	docker push ${SIDECAR_IMG}:${TAG}
+	docker push ${SIDECAR_IMG}
 
 .PHONY: docker-build-bundle
 docker-build-bundle: bundle
-	docker build -f ./bundle.Dockerfile -t ${BUNDLE_IMG}:${TAG} .
+	docker build -f ./bundle.Dockerfile -t ${BUNDLE_IMG} .
 
 .PHONY: docker-push-bundle
 docker-push-bundle:
-	docker push ${BUNDLE_IMG}:${TAG}
+	docker push ${BUNDLE_IMG}
 
 ##@ Deployment
 
@@ -152,7 +168,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}:${TAG} $(KUSTOMIZE_RBAC_PROXY)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG} $(KUSTOMIZE_RBAC_PROXY)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ NAME                                                       DESIRED   CURRENT   R
 replicaset.apps/csi-addons-controller-manager-687d47b8c7   1         1         1       49s
 ```
 
+## Contributing
+
+The [Contribution Guidelines](CONTRIBUTING.md) contain details on the process
+to contribute to this project.
+
+For feature enhancements, or questions about particular features or design
+choices, there is a mailinglist. All regular contributors are encouraged to
+subscribe to the list, and participate in the discussions.
+
+Subscribing can be done through the [mailman web interface][mailman] or by
+[sending an email to csi-addons-request@redhat.com][subscribe] with subject
+`subscribe`.
+
 [csi_addons]: https://github.com/csi-addons/spec/
 [csi]: https://kubernetes-csi.github.io/docs/
 [operatorhub]: https://operatorhub.io/
+[mailman]: https://listman.redhat.com/mailman/listinfo/csi-addons
+[subscribe]: mailto:csi-addons-request@redhat.com?subject=subscribe

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -72,3 +72,8 @@ vars:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+
+images:
+- name: rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.8.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/bases/csi-addons.clusterserviceversion.yaml
+++ b/config/manifests/bases/csi-addons.clusterserviceversion.yaml
@@ -56,8 +56,8 @@ spec:
   - name: CSI Addons
     url: https://github.com/csi-addons
   maintainers:
-  - email: ndevos@redhat.com
-    name: Niels de Vos
+  - email: csi-addons@redhat.com
+    name: CSI Addons Community
   maturity: alpha
   provider:
     name: CSI Addons Community

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,28 @@
+# Continuous Integration
+
+## GitHub Workflows
+
+The GitHub Workflows under [`.github/workflows/][workflows] contain jobs that
+are started when Pull-Requests are created or updated. Some of the jobs can
+build container-images for multiple architectures. Not everyone or all
+environmens wants to run the build tests for all platforms. The workflows can
+be configured to select platforms that the `docker/setup-buildx-action`
+supports.
+
+For this configuration, a new Secret should be created in the GitHub
+Settings of the repository. 'Normal' environment variables seem not possible.
+
+An example of the GitHub Secret that will build the container-images on AMD64,
+and both 32-bit and 64-bit Arm platforms:
+
+- `BUILD_PLATFORMS`: `linux/amd64,linux/arm64,linux/arm/v7`
+
+Detailed steps on creating the GitHub Secret can be found in [the GitHub
+Documentation][gh_doc_secret].
+
+In case the `BUILD_PLATFORMS` environment variable is not set, the
+`docker/setup-buildx-action` action defaults to the single architecture where
+the workflow is run (usually `linux/amd64`).
+
+[workflows]: .github/workflows/
+[gh_doc_secret]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository


### PR DESCRIPTION
Sync the upstream changes from `csi-addons/kubernetes-csi-addons:main` into the
`main` branch. The recent changes that are included:

5f21c38c build: enable inclusion of differently versioned container-images in the bundle
84754a72 ci: limit the platforms that are build
a854fbe4 ci: build the bundle container-image for testing
b95fd299 build: make kube-rbac-proxy container-image configurable
b6c8553c doc: promote the new csi-addons mailinglist

