### PR TITLE
Bug 2046677: controller: add pvc finalizer rbac for annotation controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,12 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/finalizers
+  verbs:
+  - update
+- apiGroups:
   - csiaddons.openshift.io
   resources:
   - csiaddonsnodes

--- a/controllers/persistentvolumeclaim_controller.go
+++ b/controllers/persistentvolumeclaim_controller.go
@@ -55,6 +55,7 @@ const (
 )
 
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/finalizers,verbs=update
 //+kubebuilder:rbac:groups=csiaddons.openshift.io,resources=reclaimspacecronjobs,verbs=get;list;watch;create;delete;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
Running pvc annotation controller on openshift throws the
following error.
```
"reclaimspacecronjobs.csiaddons.openshift.io \"pvcrbd10-1643271677\"
is forbidden: cannot set blockOwnerDeletion if an ownerReference refers
to a resource you can't set finalizers on: , <nil>"
```
Adding pvc finalizer rbac solves this issue.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit b6c48cff252709e44b7533e6c4c490384e218ce3)