### PR TITLE
Bug 2048370: CSI-Addons controller makes node reclaimspace request even when the PVC is not mounted to any pod

### DIFF
--- a/controllers/reclaimspacejob_controller_test.go
+++ b/controllers/reclaimspacejob_controller_test.go
@@ -176,3 +176,36 @@ func TestCalculateReclaimedSpace(t *testing.T) {
 		})
 	}
 }
+
+func TestCanNodeReclaimSpace(t *testing.T) {
+	tests := []struct {
+		name string
+		td   targetDetails
+		want bool
+	}{
+		{
+			name: "empty nodeID",
+			td: targetDetails{
+				driverName: "csi.example.com",
+				pvName:     "pvc-a8a5c531-9f88-4fc8-b35d-564585fb42a8",
+				nodeID:     "",
+			},
+			want: false,
+		},
+		{
+			name: "non-empty nodeID",
+			td: targetDetails{
+				driverName: "csi.example.com",
+				pvName:     "pvc-a8a5c531-9f88-4fc8-b35d-564585fb42a8",
+				nodeID:     "worker-1",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.td.canNodeReclaimSpace()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Node reclaimspace request should not be made
when nodeID is empty indicating the pvc is
not mounted to any pod and no volumeattachment
object for that PVC was found.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 110c3a5a20af2c7d321a948536c741f1e3a6368a)