### PR TITLE
BUG 2043034: use a unique label for csi-addons resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +11,18 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: csi-addons
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: csi-addons
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: csi-addons

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons


### PR DESCRIPTION
csi-addon operator is using the default label and labelSelector provided by operator-sdk:control-plane:
controller-manager for its resources, this is a generic label and it can cause problems when multiple resources uses same labels changing the label to unique one.

backport of #28

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

Manually backporting as cherry-pick failed at https://github.com/red-hat-storage/kubernetes-csi-addons/pull/28#issuecomment-1054012647