### PR TITLE
[DOWNSTREAM-ONLY] build: hide the CSI-Addons Operator from the UI

### DIFF
--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/operator-type: non-standalone
   name: @PACKAGE_NAME@.v0.1.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
As ODF-Operator is used for deploying the CSI-Addons components, the
CSI-Addons operator does not need to be visible in the OperatorHub.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2042997
Signed-off-by: Niels de Vos <ndevos@redhat.com>
(cherry picked from commit 15e9b1a9789c40ac2de2aed8ae828801a0fca4a1)

/assign Rakshith-R