### PR TITLE
ci: add quotes while executing sed for replace & skip range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ PACKAGE_NAME ?= csi-addons
 # This builds a graph of CSVs that can be queried by OLM, and updates can be
 # shared between channels. Channels can be thought of as entry points into
 # the graph of updates:
-REPLACES ?= ""
+REPLACES ?=
 
 # Creating the New CatalogSource requires publishing CSVs that replace one Operator,
 # but can skip several. This can be accomplished using the skipRange annotation:
-SKIP_RANGE ?= ""
+SKIP_RANGE ?=
 
 # By setting RBAC_PROXY_IMG to a different container-image, new versions of
 # the kube-rbac-proxy can easily be tested. Products that include CSI-Addons
@@ -99,7 +99,7 @@ manifests: controller-gen kustomize ## Generate WebhookConfiguration, ClusterRol
 
 # generate the <package-name>.clusterserviceversion.yaml base
 gen-csv-base:
-	sed 's/@PACKAGE_NAME@/$(PACKAGE_NAME)/g;s/@SKIP_RANGE@/$(SKIP_RANGE)/g;s/@REPLACES@/$(REPLACES)/g' \
+	sed 's/@PACKAGE_NAME@/$(PACKAGE_NAME)/g;s/@SKIP_RANGE@/"$(SKIP_RANGE)"/g;s/@REPLACES@/"$(REPLACES)"/g' \
 	< config/manifests/bases/clusterserviceversion.yaml.in > config/manifests/bases/$(PACKAGE_NAME).clusterserviceversion.yaml
 
 .PHONY: bundle


### PR DESCRIPTION
For the generated base csv to work, quote needs to be added
around replaces and skip_range values.

Signed-off-by: Rakshith R <rar@redhat.com>