### PR TITLE
Sync rhs:main with csi-addons:main NetworkFence: Explicitly mentioned Fenced and Unfenced state

### DIFF
--- a/api/v1alpha1/networkfence_types.go
+++ b/api/v1alpha1/networkfence_types.go
@@ -20,6 +20,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type FenceState string
+
+const (
+	// Fenced means the CIDRs should be in fenced state
+	Fenced FenceState = "Fenced"
+
+	// Unfenced means the CIDRs should be in unfenced state
+	Unfenced FenceState = "Unfenced"
+)
+
 type FencingOperationResult string
 
 const (
@@ -46,6 +56,13 @@ type NetworkFenceSpec struct {
 	// +kubebuilder:validation:Required
 	Driver string `json:"driver"`
 
+	// FenceState contains the desired state for the CIDRs
+	// mentioned in the Spec. i.e. Fenced or Unfenced
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Fenced;Unfenced
+	// +kubebuilder:default:=Fenced
+	FenceState FenceState `json:"fenceState"`
+
 	// Cidrs contains a list of CIDR blocks, which are required to be fenced.
 	// +kubebuilder:validation:Required
 	Cidrs []string `json:"cidrs"`
@@ -59,7 +76,7 @@ type NetworkFenceSpec struct {
 
 // NetworkFenceStatus defines the observed state of NetworkFence
 type NetworkFenceStatus struct {
-	// Result indicates the result of NetworkFence operation.
+	// Result indicates the result of Network Fence/Unfence operation.
 	Result FencingOperationResult `json:"result,omitempty"`
 
 	// Message contains any message from the NetworkFence operation.
@@ -73,6 +90,7 @@ type NetworkFenceStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Driver",type="string",JSONPath=".spec.driver"
 //+kubebuilder:printcolumn:name="Cidrs",type="string",JSONPath=".spec.cidrs"
+//+kubebuilder:printcolumn:name="FenceState",type="string",JSONPath=".spec.fenceState"
 //+kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 //+kubebuilder:printcolumn:JSONPath=".status.result",name=Result,type=string
 //+kubebuilder:resource:path=networkfences,scope=Cluster,singular=networkfence

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.cidrs
       name: Cidrs
       type: string
+    - jsonPath: .spec.fenceState
+      name: FenceState
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -57,6 +60,14 @@ spec:
               driver:
                 description: Driver contains  the name of CSI driver.
                 type: string
+              fenceState:
+                default: Fenced
+                description: FenceState contains the desired state for the CIDRs mentioned
+                  in the Spec. i.e. Fenced or Unfenced
+                enum:
+                - Fenced
+                - Unfenced
+                type: string
               parameters:
                 additionalProperties:
                   type: string
@@ -78,6 +89,7 @@ spec:
             required:
             - cidrs
             - driver
+            - fenceState
             type: object
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
@@ -155,7 +167,8 @@ spec:
                 description: Message contains any message from the NetworkFence operation.
                 type: string
               result:
-                description: Result indicates the result of NetworkFence operation.
+                description: Result indicates the result of Network Fence/Unfence
+                  operation.
                 type: string
             type: object
         type: object

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -129,6 +129,9 @@ spec:
     - jsonPath: .spec.cidrs
       name: Cidrs
       type: string
+    - jsonPath: .spec.fenceState
+      name: FenceState
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -164,6 +167,14 @@ spec:
               driver:
                 description: Driver contains  the name of CSI driver.
                 type: string
+              fenceState:
+                default: Fenced
+                description: FenceState contains the desired state for the CIDRs mentioned
+                  in the Spec. i.e. Fenced or Unfenced
+                enum:
+                - Fenced
+                - Unfenced
+                type: string
               parameters:
                 additionalProperties:
                   type: string
@@ -185,6 +196,7 @@ spec:
             required:
             - cidrs
             - driver
+            - fenceState
             type: object
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
@@ -262,7 +274,8 @@ spec:
                 description: Message contains any message from the NetworkFence operation.
                 type: string
               result:
-                description: Result indicates the result of NetworkFence operation.
+                description: Result indicates the result of Network Fence/Unfence
+                  operation.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
Currently, the assumption is that, the resource by default
strives to ensure that the CIDRs mentioned in the spec are
fenced. Deletion of the resource makes those CIDRs to have
been unfenced.

This has some issues when fencing is consumed for operations
such as Disaster Recovery. Hence, changed the CR to have
explicit state as either fence or unfence.

Co-authored-by: Raghavendra Talur <raghavendra.talur@gmail.com>
Signed-off-by: Raghavendra M <raghavendra@redhat.com>