### PR TITLE
Bug 2096209: reclaimspace: detect Kubernetes version for right StagingTargetPath

### DIFF
--- a/cmd/csi-addons/README.md
+++ b/cmd/csi-addons/README.md
@@ -9,21 +9,25 @@ similar to:
 
 ```console
 $ kubectl exec -c csi-addons csi-backend-nodeplugin -- csi-addons -h
+  -drivername string
+    	name of the CSI driver
   -endpoint string
     	CSI-Addons endpoint (default "unix:///tmp/csi-addons.sock")
+  -legacy
+    	use legacy format for old Kubernetes versions
   -operation string
     	csi-addons operation
   -persistentvolume string
     	name of the PersistentVolume
   -stagingpath string
-    	staging path (default "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/")
+    	staging path (default "/var/lib/kubelet/plugins/kubernetes.io/csi/")
 
 The following operations are supported:
+ - NodeReclaimSpace
  - GetIdentity
  - GetCapabilities
  - Probe
  - ControllerReclaimSpace
- - NodeReclaimSpace
 ```
 
 The above command assumes the running `csi-backend-nodeplugin` Pod has the

--- a/cmd/csi-addons/main.go
+++ b/cmd/csi-addons/main.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	endpoint    = "unix:///tmp/csi-addons.sock"
-	stagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+	stagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/"
 )
 
 // command contains the parsed arguments that were passed while running the
@@ -40,6 +40,8 @@ type command struct {
 	stagingPath      string
 	operation        string
 	persistentVolume string
+	drivername       string
+	legacy           bool
 }
 
 // cmd is the single instance of the command struct, used inside main().
@@ -50,6 +52,8 @@ func init() {
 	flag.StringVar(&cmd.stagingPath, "stagingpath", stagingPath, "staging path")
 	flag.StringVar(&cmd.operation, "operation", "", "csi-addons operation")
 	flag.StringVar(&cmd.persistentVolume, "persistentvolume", "", "name of the PersistentVolume")
+	flag.StringVar(&cmd.drivername, "drivername", "", "name of the CSI driver")
+	flag.BoolVar(&cmd.legacy, "legacy", false, "use legacy format for old Kubernetes versions")
 
 	// output to show when --help is passed
 	flag.Usage = func() {

--- a/internal/sidecar/service/reclaimspace.go
+++ b/internal/sidecar/service/reclaimspace.go
@@ -17,7 +17,10 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"path/filepath"
+	"strconv"
 
 	kube "github.com/csi-addons/kubernetes-csi-addons/internal/kubernetes"
 	"github.com/csi-addons/kubernetes-csi-addons/internal/proto"
@@ -140,7 +143,13 @@ func (rs *ReclaimSpaceServer) NodeReclaimSpace(
 		klog.Errorf("Failed to map access mode: %v", err)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	stPath := filepath.Join(rs.stagingPath, "pv", pvName, "globalmount")
+
+	stPath, err := rs.getStagingTargetPath(pv)
+	if err != nil {
+		klog.Errorf("Failed to get staging target path: %v", err)
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	accessType := csi.VolumeCapability_Mount{
 		Mount: &csi.VolumeCapability_MountVolume{},
 	}
@@ -188,4 +197,37 @@ func (rs *ReclaimSpaceServer) NodeReclaimSpace(
 	}
 
 	return res, nil
+}
+
+// getStagingTargetPath returns the path where the volume is expected to be
+// mounted (or the block-device is attached/mapped). Different Kubernetes
+// version use different paths.
+func (rs *ReclaimSpaceServer) getStagingTargetPath(pv *corev1.PersistentVolume) (string, error) {
+	// Kubernetes 1.24+ uses a hash of the volume-id in the path name
+	unique := sha256.Sum256([]byte(pv.Spec.CSI.VolumeHandle))
+	targetPath := filepath.Join(rs.stagingPath, pv.Spec.CSI.Driver, fmt.Sprintf("%x", unique), "globalmount")
+
+	version, err := rs.kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to detect Kubernetes version: %w", err)
+	}
+
+	major, err := strconv.Atoi(version.Major)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert Kubernetes major version %q to int: %w", version.Major, err)
+	}
+
+	minor, err := strconv.Atoi(version.Minor)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert Kubernetes minor version %q to int: %w", version.Minor, err)
+	}
+
+	// 'encode' major/minor in a single integer
+	legacyVersion := 1024 // Kubernetes 1.24 => 1 * 1000 + 24
+	if ((major * 1000) + minor) < (legacyVersion) {
+		// path in Kubernetes < 1.24
+		targetPath = filepath.Join(rs.stagingPath, "pv", pv.Name, "globalmount")
+	}
+
+	return targetPath, nil
 }


### PR DESCRIPTION
Bug 2096209 gets hit when then ODF is deployed on OCP-4.11 (with Kubernetes 1.24).

I hereby confirm that:

- [x] this change is in the upstream project (csi-addons/kubernetes-csi-addons#165)
- [x] this change is in the main branch of this project (#47)
- [ ] ~branches for higher versions of the project have this change merged~
- [x] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly

