### PR TITLE
crds: adds types.go file to generate crds

### DIFF
--- a/api/v1alpha1/volumereplication_types.go
+++ b/api/v1alpha1/volumereplication_types.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2021.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ReplicationState represents the replication operations to be performed on the volume.
+// +kubebuilder:validation:Enum=primary;secondary;resync
+type ReplicationState string
+
+const (
+	// Primary ReplicationState enables mirroring and promotes the volume to primary.
+	Primary ReplicationState = "primary"
+
+	// Secondary ReplicationState demotes the volume to secondary and resyncs the volume if out of sync.
+	Secondary ReplicationState = "secondary"
+
+	// Resync option resyncs the volume.
+	Resync ReplicationState = "resync"
+)
+
+// State captures the latest state of the replication operation.
+type State string
+
+const (
+	// PrimaryState represents the Primary replication state.
+	PrimaryState State = "Primary"
+
+	// SecondaryState represents the Secondary replication state.
+	SecondaryState State = "Secondary"
+
+	// UnknownState represents the Unknown replication state.
+	UnknownState State = "Unknown"
+)
+
+// VolumeReplicationSpec defines the desired state of VolumeReplication.
+type VolumeReplicationSpec struct {
+	// VolumeReplicationClass is the VolumeReplicationClass name for this VolumeReplication resource
+	// +kubebuilder:validation:Required
+	VolumeReplicationClass string `json:"volumeReplicationClass"`
+
+	// ReplicationState represents the replication operation to be performed on the volume.
+	// Supported operations are "primary", "secondary" and "resync"
+	// +kubebuilder:validation:Required
+	ReplicationState ReplicationState `json:"replicationState"`
+
+	// DataSource represents the object associated with the volume
+	// +kubebuilder:validation:Required
+	DataSource corev1.TypedLocalObjectReference `json:"dataSource"`
+
+	// AutoResync represents the volume to be auto resynced when
+	// ReplicationState is "secondary"
+	AutoResync bool `json:"autoResync"`
+
+	// replicationHandle represents an existing (but new) replication id
+	// +kubebuilder:validation:Optional
+	ReplicationHandle string `json:"replicationHandle"`
+}
+
+// VolumeReplicationStatus defines the observed state of VolumeReplication.
+type VolumeReplicationStatus struct {
+	State   State  `json:"state,omitempty"`
+	Message string `json:"message,omitempty"`
+	// Conditions are the list of conditions and their status.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// observedGeneration is the last generation change the operator has dealt with
+	// +optional
+	ObservedGeneration int64        `json:"observedGeneration,omitempty"`
+	LastStartTime      *metav1.Time `json:"lastStartTime,omitempty"`
+	LastCompletionTime *metav1.Time `json:"lastCompletionTime,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
+// +kubebuilder:printcolumn:JSONPath=".spec.volumeReplicationClass",name=volumeReplicationClass,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.dataSource.name",name=pvcName,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.replicationState",name=desiredState,type=string
+// +kubebuilder:printcolumn:JSONPath=".status.state",name=currentState,type=string
+// +kubebuilder:resource:shortName=vr
+
+// VolumeReplication is the Schema for the volumereplications API.
+type VolumeReplication struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   VolumeReplicationSpec   `json:"spec,omitempty"`
+	Status VolumeReplicationStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// VolumeReplicationList contains a list of VolumeReplication.
+type VolumeReplicationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VolumeReplication `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&VolumeReplication{}, &VolumeReplicationList{})
+}

--- a/api/v1alpha1/volumereplicationclass_types.go
+++ b/api/v1alpha1/volumereplicationclass_types.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VolumeReplicationClassSpec specifies parameters that an underlying storage system uses
+// when creating a volume replica. A specific VolumeReplicationClass is used by specifying
+// its name in a VolumeReplication object.
+type VolumeReplicationClassSpec struct {
+	// Provisioner is the name of storage provisioner
+	// +kubebuilder:validation:Required
+	Provisioner string `json:"provisioner"`
+	// Parameters is a key-value map with storage provisioner specific configurations for
+	// creating volume replicas
+	// +kubebuilder:validation:Optional
+	Parameters map[string]string `json:"parameters,omitempty"`
+}
+
+// VolumeReplicationClassStatus defines the observed state of VolumeReplicationClass.
+type VolumeReplicationClassStatus struct{}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,shortName=vrc
+// +kubebuilder:printcolumn:JSONPath=".spec.provisioner",name=provisioner,type=string
+
+// VolumeReplicationClass is the Schema for the volumereplicationclasses API.
+type VolumeReplicationClass struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   VolumeReplicationClassSpec   `json:"spec,omitempty"`
+	Status VolumeReplicationClassStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// VolumeReplicationClassList contains a list of VolumeReplicationClass.
+type VolumeReplicationClassList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VolumeReplicationClass `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&VolumeReplicationClass{}, &VolumeReplicationClassList{})
+}


### PR DESCRIPTION
This commit adds types.go file for volumereplication
and volumereplicationclass that can be used to create the
respective crds.
This is a part of movement of volume replication operator
to kubernetes-csi-addons
https://github.com/csi-addons/volume-replication-operator/tree/main/api/v1alpha1

updates: #116

Signed-off-by: yatipadia <ypadia@redhat.com>
(cherry picked from commit eb728a51c9d3cf261b61ed670d05e74590bbed57)