### PR TITLE
[DOWNSTREAM-ONLY] ci: disable Dependabot PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     labels:
       - vendor
   - package-ecosystem: "github-actions"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Depandabot automatic updating for GitHub Actions is not wanted. Changes should flow in from the upstream repository instead.

See-also: 945da3606b6e73c
Signed-off-by: Niels de Vos <ndevos@redhat.com>