### PR TITLE
Bug 2136457: replication: update LastSyncTime if its not nil

### DIFF
--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -374,9 +374,10 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 		ts := info.GetLastSyncTime()
-
-		lastSyncTime := metav1.NewTime(ts.AsTime())
-		instance.Status.LastSyncTime = &lastSyncTime
+		if ts != nil {
+			lastSyncTime := metav1.NewTime(ts.AsTime())
+			instance.Status.LastSyncTime = &lastSyncTime
+		}
 		requeueForInfo = true
 	}
 	if instance.Spec.ReplicationState == replicationv1alpha1.Secondary {

--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -57,6 +57,7 @@ const (
 var (
 	volumePromotionKnownErrors    = []codes.Code{codes.FailedPrecondition}
 	disableReplicationKnownErrors = []codes.Code{codes.NotFound}
+	getReplicationInfoKnownErrors = []codes.Code{codes.NotFound}
 )
 
 // VolumeReplicationReconciler reconciles a VolumeReplication object.
@@ -673,7 +674,11 @@ func (r *VolumeReplicationReconciler) getVolumeReplicationInfo(vr *volumeReplica
 	resp := volumeReplication.GetInfo()
 	if resp.Error != nil {
 		vr.logger.Error(resp.Error, "failed to get volume replication info")
+		if isKnownError := resp.HasKnownGRPCError(getReplicationInfoKnownErrors); isKnownError {
+			vr.logger.Info("volume/replication info not found", "volumeID", vr.commonRequestParameters.VolumeID)
 
+			return nil, nil
+		}
 		return nil, resp.Error
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/container-storage-interface/spec v1.6.0
-	github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900
+	github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8
 	github.com/go-logr/logr v1.2.3
 	github.com/kubernetes-csi/csi-lib-utils v0.11.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900 h1:zX0138DipZsZqxK1UwAmaRZmL89OuQMkwh7FtvTDgFw=
-github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
+github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8 h1:fYkq+S2FCMM/yl2BjjSNpAZjKuyPCwtkV6F155u1jiE=
+github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,7 +166,7 @@ github.com/containerd/stargz-snapshotter/estargz/errorutil
 # github.com/containerd/ttrpc v1.1.0
 ## explicit; go 1.13
 github.com/containerd/ttrpc
-# github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900
+# github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8
 ## explicit
 github.com/csi-addons/spec/lib/go/fence
 github.com/csi-addons/spec/lib/go/identity


### PR DESCRIPTION
LastSyncTime can be optional and nil also, there is no strict check for it, and if we dont have this check the [default UNIX time](https://go.dev/play/p/81CmSxr-r8S) will get added to the CR, which doesn't make sense. If the time is not present keep the last known LastSyncTime itself.

backport of https://github.com/csi-addons/kubernetes-csi-addons/pull/260