### PR TITLE
[DOWNSTREAM-ONLY] ci: disable Dependabot PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     labels:
       - vendor
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/tools"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Depandabot automatic updating for GitHub Actions is not wanted. Changes should flow in from the upstream repository instead.

Closes: #82
See-also: 945da3606b6e73c