### PR TITLE
DOWNSTRAM-ONLY: point to the right upstream project in the redhat/README

### DIFF
--- a/redhat/README.md
+++ b/redhat/README.md
@@ -12,10 +12,10 @@ This GitHub repository contains branches for different product versions.
 ## Backports
 
 All changes in this repository are *backports* from the [upstream
-project][https://github.com/ceph/ceph-csi]. There should be no functional
-changes (only process/CI/building/..) in this repository compared to the
-upstream project.  Fixes for any of the release branches should first land in
-the devel branch before they may be backported to the release branch. A
+project][https://github.com/csi-addons/kubernetes-csi-addons]. There should be
+no functional changes (only process/CI/building/..) in this repository compared
+to the upstream project. Fixes for any of the release branches should first land
+in the `main` branch before they may be backported to the release branch. A
 backport for the oldest release should also be backported to all the newer
 releases in order to prevent re-introducing a bug when a user updates.
 


### PR DESCRIPTION
Reported-in: #85