### PR TITLE
[DOWNSTREAM-ONLY] cleanup: address MarkDown linter issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
@@ -1,3 +1,5 @@
+# Backport commits to a release branch
+
 **You must EDIT ME! The contents below is an example only.**
 
 Bug 000000 gets hit when the system is out for its birthday party. After

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-downstream-only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-downstream-only.md
@@ -1,3 +1,5 @@
+# [DOWNSTREAM-ONLY] non-upstreamable changes
+
 **You must EDIT ME! The contents below is an example only.**
 
 The downstream CI testing depends on additional settings in the Search

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
@@ -1,3 +1,5 @@
+# Sync the upstream changes
+
 **You must EDIT ME! The contents below is an example only.**
 
 Sync the upstream changes from `csi-addons/kubernetes-csi-addons:main` into the

--- a/redhat/README.md
+++ b/redhat/README.md
@@ -12,12 +12,12 @@ This GitHub repository contains branches for different product versions.
 ## Backports
 
 All changes in this repository are *backports* from the [upstream
-project][https://github.com/csi-addons/kubernetes-csi-addons]. There should be
-no functional changes (only process/CI/building/..) in this repository compared
-to the upstream project. Fixes for any of the release branches should first land
-in the `main` branch before they may be backported to the release branch. A
-backport for the oldest release should also be backported to all the newer
-releases in order to prevent re-introducing a bug when a user updates.
+project][upstream-k8s-csi-addons]. There should be no functional changes (only
+process/CI/building/..) in this repository compared to the upstream project.
+Fixes for any of the release branches should first land in the `main` branch
+before they may be backported to the release branch. A backport for the oldest
+release should also be backported to all the newer releases in order to prevent
+re-introducing a bug when a user updates.
 
 ### Sync `main` with upstream `csi-addons/kubernetes-csi-addons:main`
 
@@ -38,9 +38,7 @@ upstream changes seamless.
 Once a PR has been merged in the `main` branch that fixes an issue, a new PR
 with the backport can be created. The easiest way is to use a command like
 
-```
-/cherry-pick release-4.10
-```
+    /cherry-pick release-4.10
 
 The **openshift-cherrypick-robot** will automatically create a new PR for the
 selected branch.


### PR DESCRIPTION
The `super-linter/super-linter/slim` action reports errors related to
the MarkDown templates and README. These files are not part of the
upstream project, so the corrections are _downstream only_.

Signed-off-by: Niels de Vos <ndevos@ibm.com>
