### PR TITLE
lint: update markdown file with prettier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
@@ -8,9 +8,8 @@ next day.
 
 I hereby confirm that:
 
-- [ ] this change is in the upstream project (*reference?*)
+- [ ] this change is in the upstream project (_reference?_)
 - [ ] this change is in the devel branch of this project
 - [ ] branches for higher versions of the project have this change merged
-- [ ] this PR is not *downstream-only*, if that was the case, I would have
-  explained its need very clearly
-
+- [ ] this PR is not _downstream-only_, if that was the case, I would have
+      explained its need very clearly

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
@@ -8,4 +8,3 @@ Sync the upstream changes from `csi-addons/kubernetes-csi-addons:main` into the
 - the new foz bar baz works flawlessly
 - this addresses a bug where users are facing issues with XYZ
 - ...
-

--- a/redhat/README.md
+++ b/redhat/README.md
@@ -11,7 +11,7 @@ This GitHub repository contains branches for different product versions.
 
 ## Backports
 
-All changes in this repository are *backports* from the [upstream
+All changes in this repository are _backports_ from the [upstream
 project][upstream-k8s-csi-addons]. There should be no functional changes (only
 process/CI/building/..) in this repository compared to the upstream project.
 Fixes for any of the release branches should first land in the `main` branch


### PR DESCRIPTION
This PR updates the markdown files with `prettier --write`
ref:  https://github.com/red-hat-storage/kubernetes-csi-addons/pull/186#issuecomment-2304436242