### PR TITLE
Bug 2314454: refactor parseEndpoint to accept pod names with '.' in it

### DIFF
--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -209,10 +209,6 @@ func (r *CSIAddonsNodeReconciler) resolveEndpoint(ctx context.Context, rawURL st
 		return rawURL, nil
 	} else if err != nil {
 		return "", err
-	} else if namespace == "" {
-		return "", fmt.Errorf("failed to get namespace from endpoint %q", rawURL)
-	} else if podname == "" {
-		return "", fmt.Errorf("failed to get pod from endpoint %q", rawURL)
 	}
 
 	pod := &corev1.Pod{}
@@ -248,14 +244,16 @@ func parseEndpoint(rawURL string) (string, string, string, error) {
 	}
 
 	// split hostname -> pod.namespace
-	parts := strings.Split(endpoint.Hostname(), ".")
-	podname := parts[0]
-	namespace := ""
-	if len(parts) == 2 {
-		namespace = parts[1]
-	} else if len(parts) > 2 {
-		return "", "", "", fmt.Errorf("hostname %q is not in <pod>.<namespace> format", endpoint.Hostname())
+	hostName := endpoint.Hostname()
+	lastIndex := strings.LastIndex(hostName, ".")
+
+	// check for empty podname and namespace
+	if lastIndex <= 0 || lastIndex == len(hostName)-1 {
+		return "", "", "", fmt.Errorf("hostname %q is not in <pod>.<namespace> format", hostName)
 	}
+
+	podname := hostName[0:lastIndex]
+	namespace := hostName[lastIndex+1:]
 
 	return namespace, podname, endpoint.Port(), nil
 }

--- a/internal/controller/csiaddons/csiaddonsnode_controller_test.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller_test.go
@@ -27,18 +27,28 @@ func TestParseEndpoint(t *testing.T) {
 	_, _, _, err := parseEndpoint("1.2.3.4:5678")
 	assert.True(t, errors.Is(err, errLegacyEndpoint))
 
-	namespace, podname, port, err := parseEndpoint("pod://pod-name:5678")
-	assert.NoError(t, err)
-	assert.Equal(t, namespace, "")
-	assert.Equal(t, podname, "pod-name")
-	assert.Equal(t, port, "5678")
+	// test empty namespace
+	_, _, _, err = parseEndpoint("pod://pod-name:5678")
+	assert.Error(t, err)
 
-	namespace, podname, port, err = parseEndpoint("pod://pod-name.csi-addons:5678")
+	// test empty namespace
+	_, _, _, err = parseEndpoint("pod://pod-name.:5678")
+	assert.Error(t, err)
+
+	namespace, podname, port, err := parseEndpoint("pod://pod-name.csi-addons:5678")
 	assert.NoError(t, err)
 	assert.Equal(t, namespace, "csi-addons")
 	assert.Equal(t, podname, "pod-name")
 	assert.Equal(t, port, "5678")
 
-	_, _, _, err = parseEndpoint("pod://pod.ns.cluster.local:5678")
+	namespace, podname, port, err = parseEndpoint("pod://csi.pod.ns-cluster.local:5678")
+	assert.NoError(t, err)
+	assert.Equal(t, namespace, "local")
+	assert.Equal(t, podname, "csi.pod.ns-cluster")
+	assert.Equal(t, port, "5678")
+
+	// test empty podname
+	_, _, _, err = parseEndpoint("pod://.local:5678")
 	assert.Error(t, err)
+
 }


### PR DESCRIPTION
kubernetes allows us to create pod with '.' in between, we should not limit parsing such endpoints

(cherry picked from commit https://github.com/red-hat-storage/kubernetes-csi-addons/commit/b0ae3170b0d3da85a52c92b022519c15ef709079)