### PR TITLE
[DOWNSTREAM-ONLY] add ocs default toleration to controller podspec

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,3 +69,8 @@ spec:
               memory: 64Mi
       serviceAccountName: csi-addons-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -108,3 +108,8 @@ spec:
         runAsNonRoot: true
       serviceAccountName: csi-addons-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.ocs.openshift.io/storage
+        operator: Equal
+        value: "true"


### PR DESCRIPTION
all components deployed as part of odf should tolerate this taint by default "node.ocs.openshift.io/storage=true:NoSchedule"

part of https://bugzilla.redhat.com/show_bug.cgi?id=2315651