### PR TITLE
DOWNSTREAM-ONLY: update owners aliases to add Niraj

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,3 +7,4 @@ aliases:
     - nixpanic
     - rakshith-r
     - yati1998
+    - black-dragon74


### PR DESCRIPTION
This patch adds Niraj (`black-dragon74`) to `OWNERS_ALIASES`.