### PR TITLE
DFBUGS-1261: fix empty volume group creation through cli tool

### DIFF
--- a/cmd/csi-addons/volumegroup.go
+++ b/cmd/csi-addons/volumegroup.go
@@ -75,10 +75,12 @@ func (vgb *VolumeGroupBase) SetParameters(parameters string) error {
 	return nil
 }
 
-// SetVolumeIDs sets and parses the volume IDs
+// SetVolumeIDs sets and parses the volume IDs, only if volumeids are provided.
 func (vgb *VolumeGroupBase) SetVolumeIDs(volumeids string) {
-	volumeIDs := strings.Split(volumeids, ",")
-	vgb.volumeIDs = volumeIDs
+	if volumeids != "" {
+		volumeIDs := strings.Split(volumeids, ",")
+		vgb.volumeIDs = volumeIDs
+	}
 }
 
 // Parses the parameters to convert them from string format to map[string]string format


### PR DESCRIPTION
when creating empty volume group through cli, the strings.Split() function returns a [""] value, i.e, a slice of length 1 having the value as 1 `[""]` empty string. As a result, csi panics when it tries to find the volumeID with the respective value.

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>
(cherry picked from commit f8e615a53e856013c8d2cda6c76df0174956b7c6)