### PR TITLE
Fixes typo in CSIAddonsNode file

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -68,7 +68,7 @@ type Manager struct {
 	// CSI-driver that is included in the CSIAddonsNode object.
 	Client client.Client
 
-	// Config is a ReST Config for the Kubernets API.
+	// Config is a ReST Config for the Kubernetes API.
 	Config *rest.Config
 
 	// kubernetes client to interact with the Kubernetes API.


### PR DESCRIPTION
Fix `kubernetes` typo in CSIAddonsNode file.

Signed-off-by: Bipul Adhikari <badhikar@redhat.com>
(cherry picked from commit e2faaf17ad96b980074c9b718ed06006b0934412)