### PR TITLE
DFBUGS-2142: [release-4.19]: fix: avoid panic due to incorrect logger key-value pairs

### DIFF
--- a/internal/controller/csiaddons/reclaimspacejob_controller.go
+++ b/internal/controller/csiaddons/reclaimspacejob_controller.go
@@ -394,7 +394,7 @@ func (r *ReclaimSpaceJobReconciler) controllerReclaimSpace(
 	target *targetDetails) (bool, *int64, error) {
 	controllerClient, err := r.getLeadingRSClient(ctx, r.Client, target.driverName)
 	if err != nil {
-		logger.Info("Controller Client not found: %v", err)
+		logger.Error(err, "Failed to get controller client", "driverName", target.driverName)
 		return false, nil, err
 	}
 


### PR DESCRIPTION
This commit fixes PANIC caused by an odd number of arguments
passed as key-value pairs to the structured logger. 
This ensures that all key-value pairs are correctly formatted to
prevent runtime issues during logging.

(cherry picked from commit 231913972e1bb33c762a5555a7c61828a5ae8584)
Signed-off-by: Praveen M <m.praveen@ibm.com>