### PR TITLE
[release-4.17] DFBUGS-2302: fix: avoid panic due to incorrect logger key-value pairs

### DIFF
--- a/internal/controller/csiaddons/reclaimspacejob_controller.go
+++ b/internal/controller/csiaddons/reclaimspacejob_controller.go
@@ -395,7 +395,7 @@ func (r *ReclaimSpaceJobReconciler) controllerReclaimSpace(
 	target *targetDetails) (bool, *int64, error) {
 	controllerClient, err := r.getLeadingRSClient(ctx, r.Client, target.driverName)
 	if err != nil {
-		logger.Info("Controller Client not found: %v", err)
+		logger.Error(err, "Failed to get controller client", "driverName", target.driverName)
 		return false, nil, err
 	}
 

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -55,7 +55,7 @@ type Manager struct {
 	// CSI-driver that is included in the CSIAddonsNode object.
 	Client client.Client
 
-	// Config is a ReST Config for the Kubernets API.
+	// Config is a ReST Config for the Kubernetes API.
 	Config *rest.Config
 
 	// Node is the hostname of the system where the sidecar is running.


### PR DESCRIPTION
This PR consists of changes from #287 and addresses the codespell failure. 
