### PR TITLE
[DOWNSTREAM_ONLY] deploy: Use storageclass precedence for schedule in downstream

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,7 @@ spec:
             - /csi-addons-manager
           args:
             - --namespace=$(POD_NAMESPACE)
+            - --schedule-precedence=storageclass
             - --leader-elect
             - --automaxprocs
           image: controller:latest

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -50,6 +50,7 @@ spec:
       containers:
       - args:
         - --namespace=$(POD_NAMESPACE)
+        - --schedule-precedence=storageclass
         - --leader-elect
         - --automaxprocs
         command:


### PR DESCRIPTION
This patch modifies the launch argument `schedule-precedence` to `storageclass` so that the annotations are only read from there.

This feature is tracked at: https://issues.redhat.com/browse/RHSTOR-7222