### PR TITLE
DFBUGS-3673: [release-4.18] Handle error correctly inside DispatchWatcher

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -342,7 +342,7 @@ func (mgr *Manager) DispatchWatcher() error {
 	retryCount := 0
 	node, err := mgr.getCSIAddonsNode()
 	if err != nil {
-		return errors.New("failed to get CSIAddonsNode object")
+		return fmt.Errorf("failed to get CSIAddonsNode object due to error: %w", err)
 	}
 
 	for retryCount < int(watcherRetryCount) {


### PR DESCRIPTION
This patch propagates the error returned from getCSIAddonsNode


(cherry picked from commit 486cd479ffce0ec9ef39adf66dbadddc70947ae7)