### PR TITLE
DFBUGS-3935: [DOWNSTREAM ONLY] sidecar: cleanup stale csiaddonsnode owned by DaemonSet

### DIFF
--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -139,6 +139,11 @@ func main() {
 		PodUID:       *podUID,
 	}
 
+	// If stale nodes are not cleaned up, just log and continue
+	if err := nodeMgr.CleanStaleNodes(); err != nil {
+		klog.Error(err)
+	}
+
 	// Start the watcher, it is responsible for fetching
 	// CSIAddonNode object and then calling deploy()
 	go func() {


### PR DESCRIPTION
This patch adds the functionality to remove csiaddonsnodes that are owned by a daemonset that doesn't have `-csi-addons` as the suffix.

This will delete the pre 4.20/stale csi-addons nodes.