### PR TITLE
DFBUGS-6673: [release-4.20] fix: reuse healthy connections in CSIAddonsNode reconciler

### DIFF
--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -173,6 +173,11 @@ func (c *Connection) fetchCapabilities(ctx context.Context) error {
 	return nil
 }
 
+// Endpoint returns the endpoint that was used to create this connection.
+func (c *Connection) Endpoint() string {
+	return c.endpoint
+}
+
 func (c *Connection) HasControllerService() bool {
 	for _, capability := range c.Capabilities {
 		svc := capability.GetService()

--- a/internal/connection/connection_pool.go
+++ b/internal/connection/connection_pool.go
@@ -22,10 +22,10 @@ import (
 	"log"
 	"sync"
 
+	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
+
 	coordination "k8s.io/api/coordination/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
 )
 
 const failedToReconnectFmtStr = "failed to reconnect an inactive connection due to error: %w"
@@ -48,6 +48,42 @@ func NewConnectionPool() *ConnectionPool {
 		pool:   make(map[string]*Connection),
 		rwlock: &sync.RWMutex{},
 	}
+}
+
+// GetByKey returns the connection for the given key, or nil if not found.
+func (cp *ConnectionPool) GetByKey(key string) *Connection {
+	cp.rwlock.RLock()
+	defer cp.rwlock.RUnlock()
+
+	return cp.pool[key]
+}
+
+// GetOrCreateNew returns an existing healthy connection for the given key if the
+// endpoint matches, otherwise it creates a new connection and stores it in the pool.
+// Old connection (if any) is closed when replaced by calling Put().
+func (cp *ConnectionPool) GetOrCreateNew(ctx context.Context, key, endpoint, nodeID, driverName, namespace, name string, enableAuth bool) (*Connection, error) {
+	cp.rwlock.RLock()
+	existing := cp.pool[key]
+	cp.rwlock.RUnlock()
+
+	// If a connection exists for the same endpoint
+	if existing != nil && existing.Endpoint() == endpoint {
+		// Check if it is actually healthy by calling Connect(), err will be nil
+		if err := existing.Connect(); err == nil {
+			return existing, nil
+		}
+	}
+
+	// We need to create a new connection
+	conn, err := NewConnection(ctx, endpoint, nodeID, driverName, namespace, name, enableAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	// Put it in the pool
+	cp.Put(key, conn)
+
+	return conn, nil
 }
 
 // Put adds connection object into map.

--- a/internal/connection/connection_pool_test.go
+++ b/internal/connection/connection_pool_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package connection
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -231,6 +232,78 @@ func TestConnectionPool_PutGetDelete(t *testing.T) {
 				assert.Equal(t, conn1, v)
 			}
 		}
+	})
+}
+
+func TestConnectionPool_GetOrConnect(t *testing.T) {
+	caps := []*identity.Capability{
+		{
+			Type: &identity.Capability_Service_{
+				Service: &identity.Capability_Service{
+					Type: identity.Capability_Service_CONTROLLER_SERVICE,
+				},
+			},
+		},
+	}
+
+	t.Run("creates new connection when pool is empty", func(t *testing.T) {
+		addr, cleanup := setupMockGRPCServer(t, caps)
+		defer cleanup()
+
+		cp := NewConnectionPool()
+		conn, err := cp.GetOrCreateNew(context.Background(), "key1", addr, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		assert.Equal(t, "node1", conn.NodeID)
+		assert.Equal(t, "driver1", conn.DriverName)
+
+		assert.Same(t, conn, cp.GetByKey("key1"))
+	})
+
+	t.Run("reuses healthy connection with same endpoint", func(t *testing.T) {
+		addr, cleanup := setupMockGRPCServer(t, caps)
+		defer cleanup()
+
+		cp := NewConnectionPool()
+		conn1, err := cp.GetOrCreateNew(context.Background(), "key1", addr, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+
+		conn2, err := cp.GetOrCreateNew(context.Background(), "key1", addr, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+		assert.Same(t, conn1, conn2)
+	})
+
+	t.Run("creates new connection when endpoint changes", func(t *testing.T) {
+		addr1, cleanup1 := setupMockGRPCServer(t, caps)
+		defer cleanup1()
+		addr2, cleanup2 := setupMockGRPCServer(t, caps)
+		defer cleanup2()
+
+		cp := NewConnectionPool()
+		conn1, err := cp.GetOrCreateNew(context.Background(), "key1", addr1, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+
+		conn2, err := cp.GetOrCreateNew(context.Background(), "key1", addr2, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+		assert.NotSame(t, conn1, conn2)
+		assert.Equal(t, addr2, conn2.Endpoint())
+	})
+
+	t.Run("reconnects when existing connection is unhealthy", func(t *testing.T) {
+		addr, cleanup := setupMockGRPCServer(t, caps)
+		defer cleanup()
+
+		cp := NewConnectionPool()
+		conn, err := cp.GetOrCreateNew(context.Background(), "key1", addr, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+
+		oldClient := conn.Client
+		_ = oldClient.Close()
+
+		conn2, err := cp.GetOrCreateNew(context.Background(), "key1", addr, "node1", "driver1", "ns1", "pod1", false)
+		assert.NoError(t, err)
+		assert.Same(t, conn, conn2, "should reuse the same Connection object")
+		assert.NotSame(t, oldClient, conn2.Client, "should have a new underlying gRPC client")
 	})
 }
 

--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -152,8 +152,7 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	logger.Info("Connecting to sidecar")
-	newConn, err := connection.NewConnection(ctx, endPoint, nodeID, driverName, csiAddonsNode.Namespace, csiAddonsNode.Name, r.EnableAuth)
-
+	newConn, err := r.ConnPool.GetOrCreateNew(ctx, key, endPoint, nodeID, driverName, csiAddonsNode.Namespace, csiAddonsNode.Name, r.EnableAuth)
 	// If error occurs, we retry with exponential backoff until we reach `maxRetries`
 	if err != nil {
 		// We will either:
@@ -162,17 +161,14 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.backoffAndRetry(ctx, logger, csiAddonsNode, err)
 	}
 
+	logger.Info("Successfully connected to the sidecar and added connection to the connection pool", "key", key)
+
 	nfsc, err := r.getNetworkFenceClientStatus(ctx, &logger, newConn, csiAddonsNode)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	csiAddonsNode.Status.NetworkFenceClientStatus = nfsc
-
-	logger.Info("Successfully connected to sidecar")
-	r.ConnPool.Put(key, newConn)
-	logger.Info("Added connection to connection pool", "Key", key)
-
 	csiAddonsNode.Status.State = csiaddonsv1alpha1.CSIAddonsNodeStateConnected
 	csiAddonsNode.Status.Message = "Successfully established connection with sidecar"
 	csiAddonsNode.Status.Reason = ""


### PR DESCRIPTION
The reconciler created a new gRPC connection on every requeue(1hr) closing the existing one via ConnPool.Put().

This disrupted sidecars using that connect with ExitOnConnectionLoss causing restarts.

This patches fixes the issue by ensuring that a new connection is only created when the pool has no entry, the endpoint changed, or the existing connection is unhealthy.


(cherry picked from commit 25eb4770e5a7943f89e8aaf22eed2d532eefab69)