### PR TITLE
DFBUGS-6305: [release-4.22] Allow ReclaimSpace to be disabled from StorageClasses

### DIFF
--- a/docs/reclaimspace.md
+++ b/docs/reclaimspace.md
@@ -180,3 +180,13 @@ To disable reclaim space for a specific PersistentVolumeClaim (PVC), follow thes
    ```
 
 These changes will disable reclaim space for the specified PVC.
+
+### Disabling Reclaim Space for All PersistentVolumeClaims in a StorageClass
+
+To disable reclaim space for all PVCs in a particular StorageClass, annotate the StorageClass with `reclaimspace.csiaddons.openshift.io/enable: "false"`.
+
+```bash
+kubectl annotate storageclass <SC_NAME> "reclaimspace.csiaddons.openshift.io/enable=false"
+```
+
+This action will disable reclaim space across all PVCs in that StorageClass and remove any existing `ReclaimSpaceCronJob` CRs for PVCs within it.

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -295,6 +295,7 @@ func (r *PersistentVolumeClaimReconciler) storageClassEventHandler() handler.Eve
 				utils.RsCronJobScheduleTimeAnnotation,
 				utils.KrcJobScheduleTimeAnnotation,
 				utils.KrEnableAnnotation,
+				utils.RsEnableAnnotation,
 			}
 
 			var requests []reconcile.Request
@@ -369,8 +370,8 @@ func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager, ctr
 		return err
 	}
 
-	pvcPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation)
-	scPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation)
+	pvcPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation, utils.RsEnableAnnotation)
+	scPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation, utils.RsEnableAnnotation)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -585,6 +585,25 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 		}
 	}
 
+	disabled, err := r.checkDisabledByAnnotation(ctx, logger, pvc, utils.RsEnableAnnotation)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if disabled {
+		if rsCronJob != nil {
+			err = r.Delete(ctx, rsCronJob)
+			if client.IgnoreNotFound(err) != nil {
+				errMsg := "failed to delete ReclaimSpaceCronJob"
+				logger.Error(err, errMsg)
+				return ctrl.Result{}, fmt.Errorf("%w: %s", err, errMsg)
+			}
+		}
+
+		logger.Info("ReclaimSpaceCronJob is disabled by annotation, exiting reconcile")
+		return ctrl.Result{}, nil
+	}
+
 	schedule, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, utils.RsCronJobScheduleTimeAnnotation)
 	if errors.Is(err, utils.ErrConnNotFoundRequeueNeeded) {
 		return ctrl.Result{Requeue: true}, nil

--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -122,6 +122,7 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	// Reconcile - Reclaim space
 	reclaimSpaceName := fmt.Sprintf("%s-reclaimspace", pvc.Name)
 	reclaimSpaceSched := sc.Annotations[utils.RsCronJobScheduleTimeAnnotation]
+	reclaimSpaceEnabled := sc.Annotations[utils.RsEnableAnnotation]
 	reclaimSpaceChild := &csiaddonsv1alpha1.ReclaimSpaceCronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      reclaimSpaceName,
@@ -129,7 +130,7 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		},
 	}
 
-	if err := r.reconcileFeature(ctx, logger, pvc, reclaimSpaceChild, reclaimSpaceSched, "true"); err != nil {
+	if err := r.reconcileFeature(ctx, logger, pvc, reclaimSpaceChild, reclaimSpaceSched, reclaimSpaceEnabled); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/utils/annotations.go
+++ b/internal/controller/utils/annotations.go
@@ -22,6 +22,7 @@ import (
 )
 
 var (
+	RsEnableAnnotation              = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/enable"
 	RsCronJobScheduleTimeAnnotation = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/schedule"
 	RsCronJobNameAnnotation         = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/cronjob"
 

--- a/internal/controller/utils/predicates.go
+++ b/internal/controller/utils/predicates.go
@@ -54,6 +54,7 @@ func StorageClassPredicate() predicate.Predicate {
 				KrcJobScheduleTimeAnnotation,
 				KrEnableAnnotation,
 				RsCronJobScheduleTimeAnnotation,
+				RsEnableAnnotation,
 			}
 
 			return AnnotationValueChanged(oldSC.GetAnnotations(), newSC.GetAnnotations(), relevantAnnotations)


### PR DESCRIPTION
This patch allows a user to disable reclaimspace from the annotations
on the StorageClass.

This is required for RWX block mode volumes used in VMs (to prevent sparsify op from blacklisting the actual client) .

Cherrypicked from commits: 61117744ed076dfec5a55f233a66451ecdcd1abb..b26f2725f784ebe6968dbc6c02c72e4130e12173