### PR TITLE
[release-4.16] Bump go (stdlib: net/http) from 1.21 to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/csi-addons/kubernetes-csi-addons
 
 go 1.21
 
-toolchain go1.21.5
+toolchain go1.21.9
 
 require (
 	github.com/container-storage-interface/spec v1.9.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons/tools
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/operator-framework/operator-sdk v1.34.1


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `go.mod`)
- **go (stdlib: net/http)**: `1.21` → `1.21.9` (in `tools/go.mod`)
