### PR TITLE
[release-4.17] Bump go (stdlib: net/http) from 1.22.0 to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/container-storage-interface/spec v1.10.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons/tools
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/operator-framework/operator-sdk v1.35.0


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.22.0` → `1.22.2` (in `tools/go.mod`)
- **go (stdlib: net/http)**: `1.22.0` → `1.22.2` (in `go.mod`)
