### PR TITLE
[release-4.18] Bump go (stdlib) from 1.23.0 to 1.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/container-storage-interface/spec v1.10.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/csi-addons/kubernetes-csi-addons/tools
 
-go 1.22.0
+go 1.22.7
+
 toolchain go1.22.8
 
 require (


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `go.mod`)
