### PR TITLE
[release-4.19] Bump go (stdlib) from 1.24.0 to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/container-storage-interface/spec v1.11.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons/tools
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.2
 
 require (
 	github.com/operator-framework/operator-sdk v1.38.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.0` → `1.24.2` (in `go.mod`)
- **go (stdlib)**: `1.23.0` → `1.24.2` (in `tools/go.mod`)
