### PR TITLE
DFBUGS-8935: [release-4.22] requeue reconcile requests with delay if deletion is blocked for vgrcontent

### DIFF
--- a/internal/controller/replication.storage/volumegroupreplication_controller.go
+++ b/internal/controller/replication.storage/volumegroupreplication_controller.go
@@ -337,9 +337,7 @@ func (r *VolumeGroupReplicationReconciler) Reconcile(ctx context.Context, req ct
 		} else {
 			r.log.Info("cannot delete volumeGroupReplication object yet, as the "+
 				"dependent resources are not yet deleted", "namespace", instance.Namespace, "name", instance.Name)
-			return reconcile.Result{
-				RequeueAfter: 10 * time.Second,
-			}, nil
+			return defaultRequeueForVGResources, nil
 		}
 
 		r.log.Info("volumeGroupReplication object is terminated, skipping reconciliation")

--- a/internal/controller/replication.storage/volumegroupreplicationcontent_controller.go
+++ b/internal/controller/replication.storage/volumegroupreplicationcontent_controller.go
@@ -51,6 +51,10 @@ type VolumeGroupReplicationContentReconciler struct {
 	Timeout time.Duration
 }
 
+var defaultRequeueForVGResources = ctrl.Result{
+	RequeueAfter: 15 * time.Second,
+}
+
 //+kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumegroupreplicationcontents,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumegroupreplicationcontents/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumegroupreplicationcontents/finalizers,verbs=update
@@ -175,7 +179,9 @@ func (r *VolumeGroupReplicationContentReconciler) Reconcile(ctx context.Context,
 		} else {
 			err = fmt.Errorf("cannot delete VolumeGroupReplicationContent resource, until dependent VolumeReplication instance is deleted")
 			logger.Error(err, "failed to delete VolumeGroupReplicationContent resource")
-			return reconcile.Result{}, err
+			// We should requeue with a delay as sometimes due to a failed update or multiple consecutive
+			// reconcile requests for different resources, the update gets missed and the deletion can take a long time.
+			return defaultRequeueForVGResources, err
 		}
 	}
 

--- a/internal/controller/replication.storage/volumereplication_controller.go
+++ b/internal/controller/replication.storage/volumereplication_controller.go
@@ -370,11 +370,8 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 					return ctrl.Result{}, err
 				}
 
-				return ctrl.Result{
-					Requeue: true,
-					// Setting Requeue time for 15 seconds
-					RequeueAfter: time.Second * 15,
-				}, nil
+				// Setting Requeue with delay
+				return defaultRequeueForVGResources, nil
 			}
 		} else {
 			replicationErr = r.markVolumeAsSecondary(vr)
@@ -410,11 +407,8 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 
 		if instance.Status.State == replicationv1alpha1.SecondaryState {
-			return ctrl.Result{
-				Requeue: true,
-				// in case of any error during secondary state, requeue for every 15 seconds.
-				RequeueAfter: time.Second * 15,
-			}, nil
+			// in case of any error during secondary state, requeue with a delay.
+			return defaultRequeueForVGResources, nil
 		}
 
 		return reconcile.Result{}, replicationErr


### PR DESCRIPTION
add requeue for vgrcontent reconciler with delay of 15secs, if deletion is blocked due to presence of VolumeReplication finalizer being present in VGRContent and we are waiting for it be removed by volumereplication controller because sometime due to failed update or multiple consecutive reconcile requests for different resources the update gets missed and the deletion can take a long time.
Also, added a new variable called defaultRequeueForVGResources which can be used where a requeue interval of 15secs is required for other VGR resources


(cherry picked from commit 0b886e6e331a1b05ccb88379f19702a11ccab454)